### PR TITLE
Expose SDL_RWclose

### DIFF
--- a/src/sdlrwops.ml
+++ b/src/sdlrwops.ml
@@ -35,6 +35,8 @@ let from_input_opt = function
 external alloc : unit -> t = "caml_SDL_AllocRW"
 external free : t -> unit = "caml_SDL_FreeRW"
 
+external close : t -> unit = "caml_SDL_CloseRW"
+
 type uint8 = int
 
 type uint16 = int

--- a/src/sdlrwops.mli
+++ b/src/sdlrwops.mli
@@ -37,6 +37,8 @@ val from_input_opt :
 external alloc : unit -> t = "caml_SDL_AllocRW"
 external free : t -> unit = "caml_SDL_FreeRW"
 
+external close : t -> unit = "caml_SDL_CloseRW"
+(** {{:http://wiki.libsdl.org/SDL_RWclose}api doc} *)
 
 type uint8 = int
 

--- a/src/sdlrwops_stub.c
+++ b/src/sdlrwops_stub.c
@@ -52,6 +52,13 @@ caml_SDL_FreeRW(value rwo)
     return Val_unit;
 }
 
+CAMLprim value
+caml_SDL_CloseRW(value rwo)
+{
+    SDL_RWclose(SDL_RWops_val(rwo));
+    return Val_unit;
+}
+
 #define Uint8_val(d) (Int_val(d))
 #define Val_Uint8(d) (Val_int(d))
 


### PR DESCRIPTION
The changes here expose [SDL_RWclose](http://wiki.libsdl.org/SDL_RWclose).

The difference between `SDL_FreeRW` and `SDL_RWclose` is that the latter also closes the file before freeing the `SDL_rwops` structure for it.  So, presumably, no fd leaks.
