### PR TITLE
Naked pointers removal: add missing root

### DIFF
--- a/src/sdlevent_stub.c
+++ b/src/sdlevent_stub.c
@@ -24,10 +24,12 @@
 
 static value
 Val_some(value v)
-{   
-    value some = caml_alloc(1, 0);
+{
+    CAMLparam1(v);
+    CAMLlocal1(some);
+    some = caml_alloc(1, 0);
     Store_field(some, 0, v);
-    return some;
+    CAMLreturn(some);
 }
 
 #if 0

--- a/src/sdlrect_stub.c
+++ b/src/sdlrect_stub.c
@@ -23,9 +23,11 @@
 static value
 Val_some(value v)
 {
-    value some = caml_alloc(1, 0);
+    CAMLparam1(v);
+    CAMLlocal1(some);
+    some = caml_alloc(1, 0);
     Store_field(some, 0, v);
-    return some;
+    CAMLreturn(some);
 }
 
 CAMLprim value


### PR DESCRIPTION
While auditing the naked pointers removal, I have found this missing root. Naked pointers are immediate values, and code relying on this assumption by avoiding to register roots can break when converted to a `nativeint`. This code is not tested, and for time reasons I did not take the trouble to avoid the code duplication. Would you like to pick it up from there?