### PR TITLE
Fix build issues

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -317,7 +317,7 @@ cleandeps:
 .PHONY: clean
 clean:
 	$(RM) *.[oas] *.cm[ioax] *.cmx[as] *.so *.dll *.opt *.exe
-	$(RM) *.mk *.gen.c sdl.mli
+	$(RM) *.mk *.gen.c sdl.mli sdlba.mli
 
 .PHONY: cleanall
 cleanall: clean cleandeps cleandoc

--- a/src/sdlevent_stub.c
+++ b/src/sdlevent_stub.c
@@ -13,6 +13,7 @@
 #include <caml/memory.h>
 #include <caml/alloc.h>
 #include <caml/fail.h>
+#include <caml/version.h>
 
 #include <SDL_events.h>
 #include <SDL_keyboard.h>
@@ -20,6 +21,7 @@
 #include <SDL_scancode.h>
 #include "sdlkeymod_stub.h"
 
+#if OCAML_VERSION < 41200
 #define Val_none Val_int(0)
 
 static value
@@ -31,6 +33,9 @@ Val_some(value v)
     Store_field(some, 0, v);
     CAMLreturn(some);
 }
+#else
+#define Val_some caml_alloc_some
+#endif
 
 #if 0
     SDL_WindowEvent window;           /* Window */

--- a/src/sdlrect_stub.c
+++ b/src/sdlrect_stub.c
@@ -13,11 +13,13 @@
 #include <caml/memory.h>
 #include <caml/alloc.h>
 #include <caml/fail.h>
+#include <caml/version.h>
 
 #include <SDL_rect.h>
 #include "sdlrect_stub.h"
 #include "sdlpoint_stub.h"
 
+#if OCAML_VERSION < 41200
 #define Val_none Val_int(0)
 
 static value
@@ -29,6 +31,9 @@ Val_some(value v)
     Store_field(some, 0, v);
     CAMLreturn(some);
 }
+#else
+#define Val_some caml_alloc_some
+#endif
 
 CAMLprim value
 caml_SDL_HasIntersection(value a, value b)

--- a/src/sdlrender_stub.c
+++ b/src/sdlrender_stub.c
@@ -13,6 +13,7 @@
 #include <caml/memory.h>
 #include <caml/alloc.h>
 #include <caml/fail.h>
+#include <caml/version.h>
 
 #include <SDL_render.h>
 #include "sdlrender_stub.h"
@@ -23,8 +24,10 @@
 #include "sdlpoint_stub.h"
 #include "sdlblendMode_stub.h"
 
+#if OCAML_VERSION < 41200
 #define Val_none Val_int(0)
 #define Some_val(v) Field(v,0)
+#endif
 
 CAMLprim value
 caml_SDL_CreateWindowAndRenderer(


### PR DESCRIPTION
The current code may trigger warnings due to naming conflicts with API's introduced in OCaml 4.12.0. In case of 4.12.0 or better, it will use those API's instead.

The PR also adds sdlba.mli to the list of files to remove in the "clean" make target.