### PR TITLE
Add support for HighDPI

### DIFF
--- a/src/sdlrender.ml
+++ b/src/sdlrender.ml
@@ -43,6 +43,9 @@ external create_renderer :
   flags:renderer_flags list -> t
   = "caml_SDL_CreateRenderer"
 
+external get_output_size : t -> int * int
+  = "caml_SDL_GetRendererOutputSize"
+
 external set_logical_size : t -> int * int -> unit
   = "caml_SDL_RenderSetLogicalSize"
 

--- a/src/sdlrender.mli
+++ b/src/sdlrender.mli
@@ -38,6 +38,10 @@ external create_renderer :
   = "caml_SDL_CreateRenderer"
 (** {{:http://wiki.libsdl.org/SDL_CreateRenderer}api doc} *)
 
+external get_output_size : t -> int * int
+  = "caml_SDL_GetRendererOutputSize"
+(** {{:http://wiki.libsdl.org/SDL_GetRendererOutputSize}api doc} *)
+
 external set_logical_size : t -> int * int -> unit
   = "caml_SDL_RenderSetLogicalSize"
 (** {{:http://wiki.libsdl.org/SDL_RenderSetLogicalSize}api doc} *)

--- a/src/sdlrender_stub.c
+++ b/src/sdlrender_stub.c
@@ -88,6 +88,25 @@ caml_SDL_CreateRenderer(value window, value index, value _flags)
 }
 
 CAMLprim value
+caml_SDL_GetRendererOutputSize(value renderer)
+{
+    CAMLparam1(renderer);
+    CAMLlocal1(dims);
+
+    int w, h;
+    int r = SDL_GetRendererOutputSize(
+                SDL_Renderer_val(renderer),
+                &w, &h);
+    if (r) caml_failwith("Sdlrender.get_output_size");
+
+    dims = caml_alloc_tuple(2);
+    Field(dims, 0) = Val_int(w);
+    Field(dims, 1) = Val_int(h);
+
+    CAMLreturn(dims);
+}
+
+CAMLprim value
 caml_SDL_RenderSetLogicalSize(value renderer, value dims)
 {
     value w = Field(dims,0);

--- a/src/sdlwindow.ml
+++ b/src/sdlwindow.ml
@@ -25,6 +25,7 @@ type window_flags =
   | Mouse_Focus
   | FullScreen_Desktop
   | Foreign
+  | Allow_HighDPI
 
 type window_pos = [ `centered | `undefined | `pos of int ]
 

--- a/src/sdlwindow.mli
+++ b/src/sdlwindow.mli
@@ -30,6 +30,7 @@ type window_flags =
   | Mouse_Focus
   | FullScreen_Desktop
   | Foreign
+  | Allow_HighDPI
 
 type window_pos = [ `centered | `undefined | `pos of int ]
 

--- a/src/sdlwindow_stub.c
+++ b/src/sdlwindow_stub.c
@@ -195,6 +195,7 @@ static const Uint32 caml_sdl_windowflags_table[] = {
     SDL_WINDOW_MOUSE_FOCUS,
     SDL_WINDOW_FULLSCREEN_DESKTOP,
     SDL_WINDOW_FOREIGN,
+    SDL_WINDOW_ALLOW_HIGHDPI
 };
 
 Uint32


### PR DESCRIPTION
Support for HighDPI screens have been added by implementing a binding for the SDL function SDL_GetRendererOutputSize and the Allow_HighDPI flag for window creation.