### PR TITLE
Add SDL_SetRenderTarget binding

### DIFF
--- a/src/sdlrender.ml
+++ b/src/sdlrender.ml
@@ -150,3 +150,6 @@ external get_render_drivers : unit -> renderer_info array
 
 external read_pixels : t -> ?rect:Sdlrect.t -> Sdlsurface.t -> unit
   = "caml_SDL_RenderReadPixels"
+
+external set_render_target : t -> Sdltexture.t option -> unit
+  = "caml_SDL_SetRenderTarget"

--- a/src/sdlrender.mli
+++ b/src/sdlrender.mli
@@ -171,3 +171,8 @@ external get_render_drivers : unit -> renderer_info array
 external read_pixels : t -> ?rect:Sdlrect.t -> Sdlsurface.t -> unit
   = "caml_SDL_RenderReadPixels"
 (** {{:http://wiki.libsdl.org/SDL_RenderReadPixels}api doc} *)
+
+
+external set_render_target : t -> Sdltexture.t option -> unit
+  = "caml_SDL_SetRenderTarget"
+(** {{:http://wiki.libsdl.org/SDL_SetRenderTarget}api doc} *)

--- a/src/sdlrender_stub.c
+++ b/src/sdlrender_stub.c
@@ -534,4 +534,20 @@ caml_SDL_RenderReadPixels(value renderer, value _rect, value surf)
     return Val_unit;
 }
 
+CAMLprim value
+caml_SDL_SetRenderTarget(value renderer, value texture_opt)
+{
+    SDL_Texture* texture =
+        Is_some(texture_opt) ? SDL_Texture_val(Some_val(texture_opt)) : NULL;
+
+    int r =
+        SDL_SetRenderTarget(
+            SDL_Renderer_val(renderer), 
+            texture);
+
+    if (r != 0) caml_failwith("Sdlrender.set_render_target");
+
+    return Val_unit;
+}
+
 /* vim: set ts=4 sw=4 et: */


### PR DESCRIPTION
This PR implements the useful SDL function ```SDL_SetRenderTarget``` for setting a texture as a renderer's target.

```SDL_SetRenderTarget``` accepts ```NULL``` as the destination texture, in which case the target is reverted to the renderer's default. This is implemented by the use of an explicit ```Sdltexture.t option``` argument. I considered ```?texture:Sdltexture.t```, but to clear the texture, the user would have to do ```set_render_target renderer ()``` which doesn't convey intention well.