### PR TITLE
Implement texture locking and creation with access type

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -52,6 +52,7 @@ ML_FILES_BASE = \
   sdlwindow.ml \
   sdlrender.ml \
   sdltexture.ml \
+  sdltextureAccess.ml \
   sdlpixelFormat.ml \
   sdlpixel.ml \
   sdlevent.ml \
@@ -77,6 +78,7 @@ ML_FILES = $(ML_FILES_BASE) sdl.ml
 
 ML_FILES_BA_BASE = \
   sdlsurface_ba.ml \
+  sdltexture_ba.ml \
   #End
 ML_FILES_BA = $(ML_FILES_BA_BASE) sdlba.ml
 
@@ -111,6 +113,7 @@ CSTUBS = \
 
 CSTUBS_BA = \
   sdlsurface_ba_stub.c \
+  sdltexture_ba_stub.c \
   #End
 
 C_HEADERS = \

--- a/src/sdl.ml
+++ b/src/sdl.ml
@@ -34,6 +34,9 @@ end
 module Texture = struct
   include Sdltexture
 end
+module TextureAccess = struct
+  include SdltextureAccess
+end
 module PixelFormat = struct
   include SdlpixelFormat
 end

--- a/src/sdltexture.ml
+++ b/src/sdltexture.ml
@@ -12,6 +12,10 @@
 
 type t
 
+external create :
+  Sdltype.renderer -> SdlpixelFormat.t -> SdltextureAccess.t -> int -> int -> t
+  = "caml_SDL_CreateTexture"
+
 external create_from_surface :
   Sdltype.renderer -> Sdlsurface.t -> t
   = "caml_SDL_CreateTextureFromSurface"

--- a/src/sdltexture.mli
+++ b/src/sdltexture.mli
@@ -14,6 +14,11 @@
 
 type t
 
+external create :
+  Sdltype.renderer -> SdlpixelFormat.t -> SdltextureAccess.t -> int -> int -> t
+  = "caml_SDL_CreateTexture"
+(** {{:http://wiki.libsdl.org/SDL_CreateTexture}api doc} *)
+
 external create_from_surface :
   Sdltype.renderer -> Sdlsurface.t -> t
   = "caml_SDL_CreateTextureFromSurface"

--- a/src/sdltextureAccess.ml
+++ b/src/sdltextureAccess.ml
@@ -1,0 +1,20 @@
+
+type t =
+| Static
+| Streaming
+| Target
+
+
+let to_string = function
+  | Static    -> "SDL_TEXTUREACCESS_STATIC"
+  | Streaming -> "SDL_TEXTUREACCESS_STREAMING"
+  | Target    -> "SDL_TEXTUREACCESS_TARGET"
+
+
+let of_string s =
+  match String.uppercase_ascii s with
+  | "SDL_TEXTUREACCESS_STATIC"    -> Static
+  | "SDL_TEXTUREACCESS_STREAMING" -> Streaming
+  | "SDL_TEXTUREACCESS_TARGET"    -> Target
+  | _ -> invalid_arg "SdltextureAccess.of_string"
+

--- a/src/sdltextureAccess.mli
+++ b/src/sdltextureAccess.mli
@@ -1,5 +1,5 @@
 (* OCamlSDL2 - An OCaml interface to the SDL2 library
- Copyright (C) 2014 Florent Monnier
+ Copyright (C) 2013 Florent Monnier
  
  This software is provided "AS-IS", without any express or implied warranty.
  In no event will the authors be held liable for any damages arising from
@@ -8,13 +8,14 @@
  Permission is granted to anyone to use this software for any purpose,
  including commercial applications, and to alter it and redistribute it freely.
 *)
-(** Prefixless modules, with Bigarray interactions *)
+(** Texture access kind *)
 
-module Surface_ba = struct
-  include Sdlsurface_ba
-end
+(** {{:https://wiki.libsdl.org/SDL_TextureAccess}api doc} *)
+type t =
+  | Static
+  | Streaming
+  | Target
 
-module Texture_ba = struct
-  include Sdltexture_ba
-end
+val to_string : t -> string
+val of_string : string -> t
 

--- a/src/sdltexture_ba.ml
+++ b/src/sdltexture_ba.ml
@@ -1,0 +1,27 @@
+(* OCamlSDL2 - An OCaml interface to the SDL2 library
+ Copyright (C) 2014 Piotr Mardziel
+ 
+ This software is provided "AS-IS", without any express or implied warranty.
+ In no event will the authors be held liable for any damages arising from
+ the use of this software.
+ 
+ Permission is granted to anyone to use this software for any purpose,
+ including commercial applications, and to alter it and redistribute it freely.
+*)
+(** Texture access with Bigarrays *)
+
+
+type t = Sdltexture.t
+
+external ex_lock :
+  t -> Sdlrect.t option ->  ('a, 'b) Bigarray.kind -> int -> (('a, 'b, Bigarray.c_layout) Bigarray.Array1.t * int) option
+  = "caml_SDL_Texture_ba_lock"
+(** {{:http://wiki.libsdl.org/SDL_LockTexture}api doc} *)
+
+let lock tex ?rect kind = 
+  ex_lock tex rect kind (Bigarray.kind_size_in_bytes kind)
+
+external unlock :
+  t -> unit
+  = "caml_SDL_Texture_ba_unlock" [@@noalloc]
+(** {{:http://wiki.libsdl.org/SDL_UnlockTexture}api doc} *)

--- a/src/sdltexture_ba.mli
+++ b/src/sdltexture_ba.mli
@@ -1,0 +1,24 @@
+(* OCamlSDL2 - An OCaml interface to the SDL2 library
+ Copyright (C) 2014 Piotr Mardziel
+ 
+ This software is provided "AS-IS", without any express or implied warranty.
+ In no event will the authors be held liable for any damages arising from
+ the use of this software.
+ 
+ Permission is granted to anyone to use this software for any purpose,
+ including commercial applications, and to alter it and redistribute it freely.
+*)
+(** Texture access with Bigarrays *)
+
+
+type t = Sdltexture.t
+
+val lock :
+  t -> ?rect:Sdlrect.t ->  ('a, 'b) Bigarray.kind -> (('a, 'b, Bigarray.c_layout) Bigarray.Array1.t * int) option
+(** {{:http://wiki.libsdl.org/SDL_LockTexture}api doc} *)
+
+
+external unlock :
+  t -> unit
+  = "caml_SDL_Texture_ba_unlock" [@@noalloc]
+(** {{:http://wiki.libsdl.org/SDL_UnlockTexture}api doc} *)

--- a/src/sdltexture_ba_stub.c
+++ b/src/sdltexture_ba_stub.c
@@ -1,0 +1,102 @@
+/* OCamlSDL2 - An OCaml interface to the SDL2 library
+ Copyright (C) 2014 Piotr Mardziel
+ 
+ This software is provided "AS-IS", without any express or implied warranty.
+ In no event will the authors be held liable for any damages arising from
+ the use of this software.
+ 
+ Permission is granted to anyone to use this software for any purpose,
+ including commercial applications, and to alter it and redistribute it freely.
+*/
+#define CAML_NAME_SPACE
+#include <caml/mlvalues.h>
+#include <caml/memory.h>
+#include <caml/alloc.h>
+#include <caml/fail.h>
+#include <caml/bigarray.h>
+#include <caml/version.h>
+
+#include <SDL_render.h>
+#include "sdltexture_stub.h"
+#include "sdlrect_stub.h"
+
+#if OCAML_VERSION < 41200
+#define Val_none Val_int(0)
+
+static value
+Val_some(value v)
+{
+    CAMLparam1(v);
+    CAMLlocal1(some);
+    some = caml_alloc(1, 0);
+    Store_field(some, 0, v);
+    CAMLreturn(some);
+}
+#else
+#define Val_some caml_alloc_some
+#endif
+
+CAMLprim value
+caml_SDL_Texture_ba_lock(value texture, value rect, value kind, value kind_size)
+{
+    CAMLparam4(texture, rect, kind, kind_size);
+    CAMLlocal2(tuple, ba);
+
+    SDL_Rect sdl_rect;
+    SDL_Rect* p_rect = NULL;
+
+    if (Is_some(rect))
+    {
+        p_rect = &sdl_rect;
+        SDL_Rect_val(p_rect, Some_val(rect));
+    }
+
+    SDL_Texture* sdl_texture = SDL_Texture_val(texture);
+
+    void* pixels;
+    int pitch;
+
+    int r =
+        SDL_LockTexture(
+            sdl_texture,
+            p_rect,
+            &pixels,
+            &pitch);
+
+    if (r != 0)
+    {
+        CAMLreturn(Val_none);
+    }
+
+    pitch /= Int_val(kind_size);
+
+    int height;
+    if (p_rect != NULL) {
+        height = p_rect->h;
+    } else {
+        SDL_QueryTexture(sdl_texture, NULL, NULL, NULL, &height);
+    }
+
+    long dim = height * pitch;
+    int b_flag = Caml_ba_kind_val(kind) | CAML_BA_C_LAYOUT | CAML_BA_EXTERNAL ;
+
+    tuple = caml_alloc_tuple(2);
+    ba = caml_ba_alloc_dims(b_flag, 1, pixels, dim);
+    Store_field(tuple, 0, ba);
+    Store_field(tuple, 1, Val_int(pitch));
+
+    CAMLreturn(Val_some(tuple));
+}
+
+
+CAMLprim value
+caml_SDL_Texture_ba_unlock(value texture)
+{
+    SDL_UnlockTexture(SDL_Texture_val(texture));
+
+    return Val_unit;
+}
+
+
+/* vim: set ts=4 sw=4 et: */
+

--- a/src/sdltexture_stub.c
+++ b/src/sdltexture_stub.c
@@ -16,9 +16,25 @@
  
 #include <SDL_render.h>
 #include "sdlrender_stub.h"
+#include "sdlpixelFormat_stub.h"
 #include "sdltexture_stub.h"
 #include "sdlsurface_stub.h"
 #include "sdlblendMode_stub.h"
+
+CAMLprim value
+caml_SDL_CreateTexture(value renderer, value format, value access, value w, value h)
+{
+    SDL_Texture *tex =
+        SDL_CreateTexture(
+                SDL_Renderer_val(renderer),
+                Sdl_pixelformat_t(format),
+                Int_val(access),
+                Int_val(w),
+                Int_val(h));
+    if (!tex)
+        caml_failwith("Sdltexture.create");
+    return Val_SDL_Texture(tex);
+}
 
 CAMLprim value
 caml_SDL_CreateTextureFromSurface(value renderer, value surface)


### PR DESCRIPTION
This PR comprises two parts -
    1. Creating a texture with a specific access type (for instance rendering target or CPU writeable)
    2. Support for the SDL texture locking API.

Part 1 introduces the files ```sdlTextureAccess.*``` and the function ```caml_SDL_CreateTexture``` in ```sdltexture_stub.c```

In part 2 texture locking produces a Bigarray instance, so the implementation is added to ```sdlba```, by way of the ```sdltexture_ba.*``` files.

